### PR TITLE
Set line-height explicitly in #_vit

### DIFF
--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -40,6 +40,7 @@
 
 #_vit {
   font-family: "Roboto", sans-serif;
+  line-height: 1;
   color: $text;
   *, *:before, *:after {
     outline: none;


### PR DESCRIPTION
Pages that have the `line-height` set can cause the tool have display issues.

For example, if a page has `line-height: 1.5;` set on its `body`, the message about mail-in ballots will look like this:
![with-body-line-height](https://cloud.githubusercontent.com/assets/3526/19697363/0e833b38-9ab9-11e6-90f6-85be8875b24f.png)

Notice that the "Continue" button is mostly outside the containing div.

But by setting the `line-height` on `#_vit`, we see:
![explicit-line-height-on-vit](https://cloud.githubusercontent.com/assets/3526/19697384/21c46b22-9ab9-11e6-85ed-6b7e413ec612.png)

This is currently causing problems for CO voters.

Reproducible in IE on the VIP website: http://votinginfoproject.org/projects/vip-voting-information-tool/