### PR TITLE
use proper electionAdministrationBody node

### DIFF
--- a/src/javascript/handlebars.js
+++ b/src/javascript/handlebars.js
@@ -304,7 +304,7 @@ module.exports = (function() {
   }
 
   var resourcesExist = function(data, options) {
-    if (_.has(data, 'state[0].local_jurisdiction') || _.has(data, 'state[0].electionAdministration')) {
+    if (_.has(data, 'state[0].local_jurisdiction') || _.has(data, 'state[0].electionAdministrationBody')) {
       return options.fn(this);
     } else {
       return options.inverse(this);


### PR DESCRIPTION
This helper function wasn't looking for the correct node name for `electionAdministrationBody`, and thus couldn't render when `local_jurisdiction` is also not provided.