### PR TITLE
Upgrades lodash and jquery to address Github-reported vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "browser-sync": "^2.9.3",
     "browserify": "^11.1.0",
     "cssify": "^0.7.0",
-    "gulp": "^3.9.0",
+    "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.0.1",
     "gulp-changed": "",
     "gulp-cloudfront-invalidate": "^0.1.4",
@@ -49,8 +49,8 @@
     "async": "^1.5.2",
     "console-polyfill": "^0.2.2",
     "fastclick": "",
-    "jquery": "^2.1.4",
-    "lodash": "^4.0.0",
+    "jquery": "^3.3.1",
+    "lodash": "^4.17.5",
     "tiny-binary-search": "^1.0.2"
   }
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/161192483

Note that github reported 3 vulnerabilities but I only see two listed here: https://github.com/votinginfoproject/vip-embeddable-tool/network/dependencies

This is up on staging now as well:
http://vip-voter-information-tool-staging.s3-website-us-east-1.amazonaws.com/staging.html