### PR TITLE
Apparently I missed a lodash reference, AND it is newly vulnerable since a week ago (?)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-wrap": "^0.13.0",
     "handlebars": "^4.0.2",
     "hbsfy": "^2.3.1",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.10",
     "mocha": "^2.3.4",
     "phantom": "^0.7.2",
     "pretty-hrtime": "^1.0.0",
@@ -50,7 +50,7 @@
     "console-polyfill": "^0.2.2",
     "fastclick": "",
     "jquery": "^3.3.1",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.10",
     "tiny-binary-search": "^1.0.2"
   }
 }


### PR DESCRIPTION
Follow-up to this: 
https://github.com/votinginfoproject/vip-embeddable-tool/pull/244
https://www.pivotaltracker.com/story/show/161192483

Up on staging again at
http://vip-voter-information-tool-staging.s3-website-us-east-1.amazonaws.com/staging.html
